### PR TITLE
Use correct minimum value for PacketIdentifiers

### DIFF
--- a/src/Network/MQTT/Broker/Internal.hs
+++ b/src/Network/MQTT/Broker/Internal.hs
@@ -185,7 +185,7 @@ waitPending    = void . readMVar . sessionQueuePending
 
 emptyServerQueue :: Int -> ServerQueue
 emptyServerQueue i = ServerQueue
- { queuePids         = Seq.fromList $ fmap PacketIdentifier [0 .. min i 65535]
+ { queuePids         = Seq.fromList $ fmap PacketIdentifier [1 .. min i 65535]
  , outputBuffer      = mempty
  , queueQoS0         = mempty
  , queueQoS1         = mempty


### PR DESCRIPTION
The MQTT spec bans the PacketIdentifier 0 on PUBLISH packets; non-permissive clients such as `mosquitto_sub` die whenever they recieve a QoS > 0 message. Same goes for the Rust library Rumqttc.

See http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718025
> SUBSCRIBE, UNSUBSCRIBE, and PUBLISH (in cases where QoS > 0) Control Packets MUST contain a **non-zero** 16-bit Packet Identifier

Or perhaps you would like to allow other control packets to use the identifier 0 and the fix should conditionally appear somewhere else?